### PR TITLE
Add TenantId to the Microsoft SCIM package

### DIFF
--- a/Microsoft.SCIM.WebHostSample/Microsoft.SCIM.WebHostSample.csproj
+++ b/Microsoft.SCIM.WebHostSample/Microsoft.SCIM.WebHostSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Microsoft.SCIM.csproj
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Microsoft.SCIM.csproj
@@ -1,24 +1,31 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <ProductName>Microsoft SCIM</ProductName>
+    <TargetFramework>net7.0</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Title>Microsoft SCIM</Title>
+    <AssemblyVersion>1.0.1</AssemblyVersion>
+    <Version>1.0.1</Version>
+    <FileVersion>1.0.1</FileVersion>
+    <PackageVersion>1.0.1</PackageVersion>
     <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Json.Net" Version="1.0.18" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.6.0" />
+    <PackageReference Include="Json.Net" Version="1.0.33" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.25.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.18" />
 
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="7.0.18" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
 
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/IQueryParameters.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/IQueryParameters.cs
@@ -10,5 +10,6 @@ namespace Microsoft.SCIM
     {
         IReadOnlyCollection<IFilter> AlternateFilters { get; }
         IPaginationParameters PaginationParameters { get; set; }
+        string TenantId { get; }
     }
 }

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/IResourceIdentifier.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/IResourceIdentifier.cs
@@ -8,5 +8,6 @@ namespace Microsoft.SCIM
     {
         string Identifier { get; set; }
         string SchemaIdentifier { get; set; }
+        string TenantId { get; set; }
     }
 }

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/ProtocolExtensions.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/ProtocolExtensions.cs
@@ -700,6 +700,7 @@ namespace Microsoft.SCIM
                     schemaIdentifier,
                     path,
                     resource.Identifier,
+                    resource.TenantId,
                     requestedAttributePaths,
                     excludedAttributePaths);
             string query = retrievalParameters.ToString();
@@ -831,7 +832,7 @@ namespace Microsoft.SCIM
                 schemaIdentifier = resource.GetSchemaIdentifier();
             }
 
-            IResourceIdentifier result = new ResourceIdentifier(schemaIdentifier, resource.Identifier);
+            IResourceIdentifier result = new ResourceIdentifier(schemaIdentifier, resource.Identifier, resource.TenantId);
             return result;
         }
 

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/QueryParameters.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/QueryParameters.cs
@@ -12,6 +12,7 @@ namespace Microsoft.SCIM
         public QueryParameters(
             string schemaIdentifier,
             string path,
+            string tenantId,
             IFilter filter,
             IReadOnlyCollection<string> requestedAttributePaths,
             IReadOnlyCollection<string> excludedAttributePaths)
@@ -22,25 +23,29 @@ namespace Microsoft.SCIM
                 throw new ArgumentNullException(nameof(filter));
             }
 
+            this.TenantId = tenantId;
             this.AlternateFilters = filter.ToCollection();
         }
 
         public QueryParameters(
             string schemaIdentifier,
             string path,
+            string tenantId,
             IReadOnlyCollection<IFilter> alternateFilters,
             IReadOnlyCollection<string> requestedAttributePaths,
             IReadOnlyCollection<string> excludedAttributePaths)
             : base(schemaIdentifier, path, requestedAttributePaths, excludedAttributePaths)
         {
+            this.TenantId = tenantId;
             this.AlternateFilters = alternateFilters ?? throw new ArgumentNullException(nameof(alternateFilters));
         }
 
         public QueryParameters(
             string schemaIdentifier,
             string path,
+            string tenantId,
             IPaginationParameters paginationParameters)
-            : this(schemaIdentifier, path, Array.Empty<IFilter>(), Array.Empty<string>(), Array.Empty<string>())
+            : this(schemaIdentifier, path, tenantId, Array.Empty<IFilter>(), Array.Empty<string>(), Array.Empty<string>())
         {
             this.PaginationParameters = paginationParameters ?? throw new ArgumentNullException(nameof(paginationParameters));
         }
@@ -48,11 +53,13 @@ namespace Microsoft.SCIM
         [Obsolete("Use QueryParameters(string, string, IFilter, IReadOnlyCollection<string>, IReadOnlyCollection<string>) instead")]
         public QueryParameters(
             string schemaIdentifier,
+            string tenantId,
             IFilter filter,
             IReadOnlyCollection<string> requestedAttributePaths,
             IReadOnlyCollection<string> excludedAttributePaths)
             : this(
                 schemaIdentifier,
+                tenantId,
                 new SchemaIdentifier(schemaIdentifier).FindPath(),
                 filter,
                 requestedAttributePaths,
@@ -63,17 +70,21 @@ namespace Microsoft.SCIM
         [Obsolete("Use QueryParameters(string, string, IReadOnlyCollection<IFilter>, IReadOnlyCollection<string>, IReadOnlyCollection<string>) instead")]
         public QueryParameters(
             string schemaIdentifier,
+            string tenantId,
             IReadOnlyCollection<IFilter> alternateFilters,
             IReadOnlyCollection<string> requestedAttributePaths,
             IReadOnlyCollection<string> excludedAttributePaths)
             : this(
                 schemaIdentifier,
+                tenantId,
                 new SchemaIdentifier(schemaIdentifier).FindPath(),
                 alternateFilters,
                 requestedAttributePaths,
                 excludedAttributePaths)
         {
         }
+
+        public string TenantId { get; }
 
         public IReadOnlyCollection<IFilter> AlternateFilters
         {

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/ResourceIdentifier.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/ResourceIdentifier.cs
@@ -13,7 +13,7 @@ namespace Microsoft.SCIM
         {
         }
 
-        public ResourceIdentifier(string schemaIdentifier, string resourceIdentifier)
+        public ResourceIdentifier(string schemaIdentifier, string resourceIdentifier, string tenantId)
         {
             if (string.IsNullOrWhiteSpace(schemaIdentifier))
             {
@@ -27,8 +27,15 @@ namespace Microsoft.SCIM
 
             this.SchemaIdentifier = schemaIdentifier;
             this.Identifier = resourceIdentifier;
+            this.TenantId = tenantId;
         }
 
+        public string TenantId
+        {
+            get;
+            set;
+        }
+        
         public string Identifier
         {
             get;
@@ -64,6 +71,11 @@ namespace Microsoft.SCIM
                 return false;
             }
 
+            if (!string.Equals(this.TenantId, otherIdentifier.TenantId, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
             return true;
         }
 
@@ -71,7 +83,8 @@ namespace Microsoft.SCIM
         {
             int identifierCode = string.IsNullOrWhiteSpace(this.Identifier) ? 0 : this.Identifier.GetHashCode(StringComparison.InvariantCulture);
             int schemaIdentifierCode = string.IsNullOrWhiteSpace(this.SchemaIdentifier) ? 0 : this.SchemaIdentifier.GetHashCode(StringComparison.InvariantCulture);
-            int result = identifierCode ^ schemaIdentifierCode;
+            int tenantIdentifierCode = string.IsNullOrWhiteSpace(this.TenantId) ? 0 : this.TenantId.GetHashCode(StringComparison.InvariantCulture);
+            int result = identifierCode ^ schemaIdentifierCode ^ tenantIdentifierCode;
             return result;
         }
 

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/ResourceRetrievalParameters.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/ResourceRetrievalParameters.cs
@@ -13,6 +13,7 @@ namespace Microsoft.SCIM
             string schemaIdentifier,
             string path,
             string resourceIdentifier,
+            string tenantId,
             IReadOnlyCollection<string> requestedAttributePaths,
             IReadOnlyCollection<string> excludedAttributePaths)
             : base(schemaIdentifier, path, requestedAttributePaths, excludedAttributePaths)
@@ -26,14 +27,16 @@ namespace Microsoft.SCIM
                 new ResourceIdentifier()
                 {
                     Identifier = resourceIdentifier,
-                    SchemaIdentifier = this.SchemaIdentifier
+                    SchemaIdentifier = this.SchemaIdentifier,
+                    TenantId = tenantId
                 };
         }
 
         public ResourceRetrievalParameters(
             string schemaIdentifier,
             string path,
-            string resourceIdentifier)
+            string resourceIdentifier,
+            string tenantId)
             : base(schemaIdentifier, path)
         {
             if (null == resourceIdentifier)
@@ -45,7 +48,8 @@ namespace Microsoft.SCIM
                 new ResourceIdentifier()
                 {
                     Identifier = resourceIdentifier,
-                    SchemaIdentifier = this.SchemaIdentifier
+                    SchemaIdentifier = this.SchemaIdentifier,
+                    TenantId = tenantId
                 };
         }
 

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/Resource.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/Resource.cs
@@ -10,6 +10,13 @@ namespace Microsoft.SCIM
     [DataContract]
     public abstract class Resource : Schematized
     {
+        public virtual string TenantId
+        {
+            get;
+            set;
+        }
+
+
         [DataMember(Name = AttributeNames.ExternalIdentifier, IsRequired = false, EmitDefaultValue = false)]
         public string ExternalIdentifier
         {

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Service/IProviderAdapter.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Service/IProviderAdapter.cs
@@ -9,7 +9,7 @@ namespace Microsoft.SCIM
     public interface IProviderAdapter<T> where T : Resource
     {
         string SchemaIdentifier { get; }
-
+        string GetTenantId(HttpRequestMessage message);
         Task<Resource> Create(HttpRequestMessage request, Resource resource, string correlationIdentifier);
         Task Delete(HttpRequestMessage request, string identifier, string correlationIdentifier);
         Task<QueryResponseBase> Query(

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Service/RootProviderAdapter .cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Service/RootProviderAdapter .cs
@@ -31,7 +31,7 @@ namespace Microsoft.SCIM
             throw new HttpResponseException(HttpStatusCode.NotImplemented);
         }
 
-        public override IResourceIdentifier CreateResourceIdentifier(string identifier)
+        public override IResourceIdentifier CreateResourceIdentifier(HttpRequestMessage message, string identifier)
         {
             throw new HttpResponseException(HttpStatusCode.NotImplemented);
         }


### PR DESCRIPTION
This PR allows the SCIM code to be multi-tenanted to support SAAS solutions in the cloud for multiple customers.
A TenantId (string) is used to denote some CustomerId and is passed/set in all Resources and APIs.

As well as this the projects will be updated to support Net 7,0 and a NuGet config is also included.

Add TenantId to the Microsoft SCIM package

Add TenantId to the Resource.cs and related classes (IResourceIdentifier.cs and IQueryParameters.cs)
Add TenantId to the IProviderAdapter.cs
Expose the TenantId in the ProviderAdapterTemplate.cs
Update to Net 7.0