### PR TITLE
Fix the serialization to better handle Dates and Collections

### DIFF
--- a/Microsoft.SystemForCrossDomainIdentityManagement/Microsoft.SCIM.csproj
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Microsoft.SCIM.csproj
@@ -5,10 +5,10 @@
     <TargetFramework>net7.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Title>Microsoft SCIM</Title>
-    <AssemblyVersion>1.0.2</AssemblyVersion>
-    <Version>1.0.2</Version>
-    <FileVersion>1.0.2</FileVersion>
-    <PackageVersion>1.0.2</PackageVersion>
+    <AssemblyVersion>1.0.3</AssemblyVersion>
+    <Version>1.0.3</Version>
+    <FileVersion>1.0.3</FileVersion>
+    <PackageVersion>1.0.3</PackageVersion>
     <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>
 

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/SchematizedJsonDeserializingFactory.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/SchematizedJsonDeserializingFactory.cs
@@ -2,6 +2,8 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
 
+using Newtonsoft.Json.Linq;
+
 namespace Microsoft.SCIM
 {
     using System;
@@ -161,7 +163,14 @@ namespace Microsoft.SCIM
             switch (value)
             {
                 case IEnumerable schemas:
-                    schemaIdentifiers = schemas.ToCollection<string>();
+                    try
+                    {
+                        schemaIdentifiers = ((JArray)schemas).Values<string>().ToCollection<string>();
+                    }
+                    catch(ArgumentException)
+                    {
+                        schemaIdentifiers = schemas.ToCollection<string>();
+                    }
                     break;
                 default:
                     throw new ArgumentException(

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/JsonFactory.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/JsonFactory.cs
@@ -99,40 +99,48 @@ namespace Microsoft.SCIM
 
         private class Implementation : JsonFactory
         {
+            /// <summary>
+            ///     The default DateParseHandling results in a non-JSON compliant string as the date, DateParseHandling.None forces the
+            ///     correct JSON date format.
+            /// </summary>
+            private static readonly JsonSerializerSettings JsonSerializerSettings = new() { DateParseHandling = DateParseHandling.None };
+
             public override Dictionary<string, object> Create(string json)
             {
                 try
                 {
-                    Dictionary<string, object> result =
-                        JsonConvert.DeserializeObject<Dictionary<string, object>>(json);
-                    return result;
+                    return JsonConvert.DeserializeObject<Dictionary<string, object>>(json, JsonSerializerSettings);
                 }
-                finally
+                catch (InvalidCastException)
                 {
+                    var result =
+                        (Dictionary<string, object>)JsonConvert.DeserializeObject(
+                            json, JsonSerializerSettings);
+                    return result;
                 }
             }
 
             public override string Create(string[] json)
             {
-                string result = JsonConvert.SerializeObject(json);
+                string result = JsonConvert.SerializeObject(json, JsonSerializerSettings);
                 return result;
             }
 
             public override string Create(Dictionary<string, object> json)
             {
-                string result = JsonConvert.SerializeObject(json);
+                string result = JsonConvert.SerializeObject(json, JsonSerializerSettings);
                 return result;
             }
 
             public override string Create(IDictionary<string, object> json)
             {
-                string result = JsonConvert.SerializeObject(json);
+                string result = JsonConvert.SerializeObject(json, JsonSerializerSettings);
                 return result;
             }
 
             public override string Create(IReadOnlyDictionary<string, object> json)
             {
-                string result = JsonConvert.SerializeObject(json);
+                string result = JsonConvert.SerializeObject(json, JsonSerializerSettings);
                 return result;
             }
         }

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/TrustedJsonFactory.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/TrustedJsonFactory.cs
@@ -2,6 +2,8 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.SCIM
 {
     using System.Collections.Generic;
@@ -9,35 +11,48 @@ namespace Microsoft.SCIM
 
     public class TrustedJsonFactory : JsonFactory
     {
+        /// <summary>
+        ///     The default DateParseHandling results in a non-JSON compliant string as the date, DateParseHandling.None forces the
+        ///     correct JSON date format.
+        /// </summary>
+        private static readonly JsonSerializerSettings JsonSerializerSettings = new() { DateParseHandling = DateParseHandling.None };
+
         public override Dictionary<string, object> Create(string json)
         {
-            Dictionary<string, object> result =
-                (Dictionary<string, object>)JsonConvert.DeserializeObject(
-                    json);
-            return result;
+            try
+            {
+                return JsonConvert.DeserializeObject<Dictionary<string, object>>(json, JsonSerializerSettings);
+            }
+            catch (InvalidCastException)
+            {
+                var result =
+                    (Dictionary<string, object>)JsonConvert.DeserializeObject(
+                        json, JsonSerializerSettings);
+                return result;
+            }
         }
 
         public override string Create(string[] json)
         {
-            string result = JsonConvert.SerializeObject(json);
+            string result = JsonConvert.SerializeObject(json, JsonSerializerSettings);
             return result;
         }
 
         public override string Create(Dictionary<string, object> json)
         {
-            string result = JsonConvert.SerializeObject(json);
+            string result = JsonConvert.SerializeObject(json, JsonSerializerSettings);
             return result;
         }
 
         public override string Create(IDictionary<string, object> json)
         {
-            string result = JsonConvert.SerializeObject(json);
+            string result = JsonConvert.SerializeObject(json, JsonSerializerSettings);
             return result;
         }
 
         public override string Create(IReadOnlyDictionary<string, object> json)
         {
-            string result = JsonConvert.SerializeObject(json);
+            string result = JsonConvert.SerializeObject(json, JsonSerializerSettings);
             return result;
         }
     }

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Service/Controllers/ControllerTemplate.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Service/Controllers/ControllerTemplate.cs
@@ -551,7 +551,7 @@ namespace Microsoft.SCIM
                     monitor.Report(notification);
                 }
 
-                throw;
+                return this.ScimError(HttpStatusCode.BadRequest, exception.Message);
             }
         }
 
@@ -649,7 +649,7 @@ namespace Microsoft.SCIM
                     monitor.Report(notification);
                 }
 
-                throw;
+                return this.ScimError(HttpStatusCode.BadRequest, exception.Message);
             }
         }
 


### PR DESCRIPTION
The serialization code was using outdated assumptions for the datatypes and dates.
Since updating to net7.0 these functions didn't work as expected.

This PR fixes these issues to ensure the serialization/de-serialization works as expected 

Fix the serialization to better handle Dates and Collections
- Update the JsonFactory.cs and TrustedJsonFactory.cs to use Json Date formatting
- Update the SchematizedJsonDeserializingFactory.cs to correctly get items from the JArray and assume as the default data type
- Return better errors from the ControllerTemplate.cs
- Update the NuGet version