### PR TITLE
Fix an issue with the DataContractSerializer not being able to handle Boolean as "True"

### DIFF
--- a/Microsoft.SystemForCrossDomainIdentityManagement/Microsoft.SCIM.csproj
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Microsoft.SCIM.csproj
@@ -5,10 +5,10 @@
     <TargetFramework>net7.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Title>Microsoft SCIM</Title>
-    <AssemblyVersion>1.0.3</AssemblyVersion>
-    <Version>1.0.3</Version>
-    <FileVersion>1.0.3</FileVersion>
-    <PackageVersion>1.0.3</PackageVersion>
+    <AssemblyVersion>1.0.4</AssemblyVersion>
+    <Version>1.0.4</Version>
+    <FileVersion>1.0.4</FileVersion>
+    <PackageVersion>1.0.4</PackageVersion>
     <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>
 


### PR DESCRIPTION
Fix an issue with the DataContractSerializer not being able to handle Boolean as "True"
- Update the JsonDeserializingFactory.cs with a ParseJson() function that updates "True" to "true" for all JProperties
- Update the NuGet version