### PR TITLE
Ensure the date format is ISO 8601 as per the SCIM format

### DIFF
--- a/Microsoft.SCIM.WebHostSample/Microsoft.SCIM.WebHostSample.csproj
+++ b/Microsoft.SCIM.WebHostSample/Microsoft.SCIM.WebHostSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Microsoft.SCIM.sln
+++ b/Microsoft.SCIM.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.SCIM", "Microsoft
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.SCIM.WebHostSample", "Microsoft.SCIM.WebHostSample\Microsoft.SCIM.WebHostSample.csproj", "{238F1B05-D3EE-4AB4-871E-ADEA0A1665CF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.SystemForCrossDomainIdentityManagement.Tests", "Microsoft.SystemForCrossDomainIdentityManagement.Tests\Microsoft.SystemForCrossDomainIdentityManagement.Tests.csproj", "{B1D7B263-EA5B-4F7A-B5F3-3A697DA6BD56}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{238F1B05-D3EE-4AB4-871E-ADEA0A1665CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{238F1B05-D3EE-4AB4-871E-ADEA0A1665CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{238F1B05-D3EE-4AB4-871E-ADEA0A1665CF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1D7B263-EA5B-4F7A-B5F3-3A697DA6BD56}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1D7B263-EA5B-4F7A-B5F3-3A697DA6BD56}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1D7B263-EA5B-4F7A-B5F3-3A697DA6BD56}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1D7B263-EA5B-4F7A-B5F3-3A697DA6BD56}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Microsoft.SystemForCrossDomainIdentityManagement.Tests/Core2EnterpriseUserJsonDeserializingFactoryTests.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement.Tests/Core2EnterpriseUserJsonDeserializingFactoryTests.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.SCIM;
+
+namespace Microsoft.SystemForCrossDomainIdentityManagement.Tests;
+
+public class Core2EnterpriseUserJsonDeserializingFactoryTests
+{
+    private const string Core2EnterpriseUserString = "{\n  \"active\" : true,\n  \"displayName\" : \"test user1\",\n  \"emails\" : [ {\n    \"type\" : \"work\",\n    \"primary\" : true,\n    \"value\" : \"test.user1@somedomain.com\"\n  } ],\n  \"locale\" : \"en-US\",\n  \"meta\" : {\n    \"resourceType\" : null,\n    \"created\" : \"2025-12-10T22:52:06.4081651\",\n    \"lastModified\" : \"2025-12-10T22:52:06.4439685\",\n    \"version\" : null,\n    \"location\" : \"\"\n  },\n  \"name\" : {\n    \"familyName\" : \"user123\",\n    \"givenName\" : \"test\"\n  },\n  \"userName\" : \"test.user1@somedomain.com\",\n  \"externalId\" : \"00uy542fqumJzNFq2697\",\n  \"id\" : \"z4dl6zdheglurdnuc4mwn54kcq@somedomain.local\",\n  \"schemas\" : [ \"urn:ietf:params:scim:schemas:core:2.0:User\" ],\n  \"groups\" : [ ]\n}";
+
+    [Fact]
+    public void Create()
+    {
+        var core2EnterpriseUserJsonDeserializingFactory = new Core2EnterpriseUserJsonDeserializingFactory();
+        var core2EnterpriseUser = core2EnterpriseUserJsonDeserializingFactory.Create(Core2EnterpriseUserString);
+        Assert.NotNull(core2EnterpriseUser);
+    }
+}

--- a/Microsoft.SystemForCrossDomainIdentityManagement.Tests/Microsoft.SystemForCrossDomainIdentityManagement.Tests.csproj
+++ b/Microsoft.SystemForCrossDomainIdentityManagement.Tests/Microsoft.SystemForCrossDomainIdentityManagement.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Microsoft.SystemForCrossDomainIdentityManagement\Microsoft.SCIM.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Microsoft.SCIM.csproj
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Microsoft.SCIM.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <ProductName>Microsoft SCIM</ProductName>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Title>Microsoft SCIM</Title>
-    <AssemblyVersion>1.0.4</AssemblyVersion>
-    <Version>1.0.4</Version>
-    <FileVersion>1.0.4</FileVersion>
-    <PackageVersion>1.0.4</PackageVersion>
+    <AssemblyVersion>1.0.5</AssemblyVersion>
+    <Version>1.0.5</Version>
+    <FileVersion>1.0.5</FileVersion>
+    <PackageVersion>1.0.5</PackageVersion>
     <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>
 

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/JsonDeserializingFactory.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/JsonDeserializingFactory.cs
@@ -16,12 +16,7 @@ namespace Microsoft.SCIM
     public abstract class JsonDeserializingFactory<TDataContract> : IJsonNormalizationBehavior
     {
         private static readonly Lazy<DataContractJsonSerializerSettings> JsonSerializerSettings =
-            new Lazy<DataContractJsonSerializerSettings>(
-                () =>
-                    new DataContractJsonSerializerSettings()
-                    {
-                        EmitTypeInformation = EmitTypeInformation.Never
-                    });
+            new Lazy<DataContractJsonSerializerSettings>(SCIM.JsonSerializer.GetDataContractJsonSerializerSettings);
 
         private static readonly Lazy<DataContractJsonSerializer> JsonSerializer =
             new Lazy<DataContractJsonSerializer>(

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/JsonSerializer.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/JsonSerializer.cs
@@ -12,13 +12,16 @@ namespace Microsoft.SCIM
 
     internal class JsonSerializer : IJsonSerializable
     {
+        public static DataContractJsonSerializerSettings GetDataContractJsonSerializerSettings() 
+            => new ()
+        {
+            EmitTypeInformation = EmitTypeInformation.Never,
+            // SCIM uses the ISO 8601 which is the round trip - https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#Roundtrip
+            DateTimeFormat = new DateTimeFormat("O")
+        };
+
         private static readonly Lazy<DataContractJsonSerializerSettings> SerializerSettings =
-            new Lazy<DataContractJsonSerializerSettings>(
-                () =>
-                    new DataContractJsonSerializerSettings()
-                    {
-                        EmitTypeInformation = EmitTypeInformation.Never
-                    });
+            new Lazy<DataContractJsonSerializerSettings>(GetDataContractJsonSerializerSettings);
 
         private readonly object dataContractValue;
 


### PR DESCRIPTION
When testing with real data from Okta the dates were being rejected with an error
```
System.Runtime.Serialization.SerializationException: There was an error deserializing the object of type Microsoft.SCIM.Core2EnterpriseUser. DateTime content '2025-12-10T22:52:06.4081651' does not start with '\/Date(' and end with ')\/' as required for JSON.
 ---> System.FormatException: DateTime content '2025-12-10T22:52:06.4081651' does not start with '\/Date(' and end with ')\/' as required for JSON.
```

This is due to the default Serialization using the old(er) MS DateFormat.

This PR forces the DatFormat to be ISO 8601.
As well as this the projects were updated to net90.

Ensure the date format is ISO 8601 as per the SCIM format
- Update the JsonDeserializingFactory.cs and JsonSerializer.cs to set the DateTimeFormat to DateTimeFormat("O")
- Update projects to net90
- Add tests project