### PR TITLE
CA-11833: Upgrade SCIMReferenceCode to .NET 10

### DIFF
--- a/Microsoft.SCIM.WebHostSample/Microsoft.SCIM.WebHostSample.csproj
+++ b/Microsoft.SCIM.WebHostSample/Microsoft.SCIM.WebHostSample.csproj
@@ -1,8 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.SystemForCrossDomainIdentityManagement\Microsoft.SCIM.csproj" />

--- a/Microsoft.SCIM.WebHostSample/Provider/InMemoryGroupProvider.cs
+++ b/Microsoft.SCIM.WebHostSample/Provider/InMemoryGroupProvider.cs
@@ -8,7 +8,6 @@ namespace Microsoft.SCIM.WebHostSample.Provider
     using System.Linq.Expressions;
     using System.Net;
     using System.Threading.Tasks;
-    using System.Web.Http;
     using Microsoft.SCIM;
 
     public class InMemoryGroupProvider : ProviderBase

--- a/Microsoft.SCIM.WebHostSample/Provider/InMemoryUserProvider.cs
+++ b/Microsoft.SCIM.WebHostSample/Provider/InMemoryUserProvider.cs
@@ -8,7 +8,6 @@ namespace Microsoft.SCIM.WebHostSample.Provider
     using System.Linq.Expressions;
     using System.Net;
     using System.Threading.Tasks;
-    using System.Web.Http;
     using Microsoft.SCIM;
 
     public class InMemoryUserProvider : ProviderBase

--- a/Microsoft.SCIM.WebHostSample/appsettings.Development.json
+++ b/Microsoft.SCIM.WebHostSample/appsettings.Development.json
@@ -9,7 +9,7 @@
   "Token": {
     "TokenAudience": "Microsoft.Security.Bearer",
     "TokenIssuer": "Microsoft.Security.Bearer",
-    "IssuerSigningKey": "A1B2C3D4E5F6A1B2C3D4E5F6",
+    "IssuerSigningKey": "A1B2C3D4E5F6A1B2C3D4E5F6G7H8I9J0",
     "TokenLifetimeInMins": "120"
   }
 }

--- a/Microsoft.SystemForCrossDomainIdentityManagement.Tests/Microsoft.SystemForCrossDomainIdentityManagement.Tests.csproj
+++ b/Microsoft.SystemForCrossDomainIdentityManagement.Tests/Microsoft.SystemForCrossDomainIdentityManagement.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Microsoft.SCIM.csproj
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Microsoft.SCIM.csproj
@@ -2,34 +2,26 @@
 
   <PropertyGroup>
     <ProductName>Microsoft SCIM</ProductName>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Title>Microsoft SCIM</Title>
-    <AssemblyVersion>1.0.5</AssemblyVersion>
-    <Version>1.0.5</Version>
-    <FileVersion>1.0.5</FileVersion>
-    <PackageVersion>1.0.5</PackageVersion>
+    <AssemblyVersion>1.0.6</AssemblyVersion>
+    <Version>1.0.6</Version>
+    <FileVersion>1.0.6</FileVersion>
+    <PackageVersion>1.0.6</PackageVersion>
     <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Json.Net" Version="1.0.33" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.25.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.18" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Json.Net" Version="1.0.33" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="7.0.18" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
-
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-
   </ItemGroup>
 
   <ItemGroup>

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/ProtocolExtensions.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/ProtocolExtensions.cs
@@ -11,7 +11,6 @@ namespace Microsoft.SCIM
     using System.IO;
     using System.Linq;
     using System.Net.Http;
-    using System.Net.Http.Formatting;
     using System.Text;
     using System.Text.RegularExpressions;
     using System.Threading.Tasks;
@@ -444,12 +443,10 @@ namespace Microsoft.SCIM
                 {
                     string contentType = MediaTypes.Protocol;
 
-                    MediaTypeFormatter contentFormatter = new JsonMediaTypeFormatter();
-                    requestContent =
-                        new ObjectContent<Dictionary<string, object>>(
-                            json,
-                            contentFormatter,
-                            contentType);
+                    requestContent = new StringContent(
+                        JsonConvert.SerializeObject(json),
+                        Encoding.UTF8,
+                        contentType);
                     result = new HttpRequestMessage(ProtocolExtensions.PatchMethod, resourceIdentifier);
                     result.Content = requestContent;
                     requestContent = null;
@@ -499,12 +496,10 @@ namespace Microsoft.SCIM
                 HttpContent requestContent = null;
                 try
                 {
-                    MediaTypeFormatter contentFormatter = new JsonMediaTypeFormatter();
-                    requestContent =
-                        new ObjectContent<Dictionary<string, object>>(
-                            json,
-                            contentFormatter,
-                            MediaTypes.Json);
+                    requestContent = new StringContent(
+                        JsonConvert.SerializeObject(json),
+                        Encoding.UTF8,
+                        MediaTypes.Json);
                     result = new HttpRequestMessage(ProtocolExtensions.PatchMethod, resourceIdentifier);
                     result.Content = requestContent;
                     requestContent = null;
@@ -555,12 +550,10 @@ namespace Microsoft.SCIM
                 HttpContent requestContent = null;
                 try
                 {
-                    MediaTypeFormatter contentFormatter = new JsonMediaTypeFormatter();
-                    requestContent =
-                        new ObjectContent<Dictionary<string, object>>(
-                            json,
-                            contentFormatter,
-                            contentType);
+                    requestContent = new StringContent(
+                        JsonConvert.SerializeObject(json),
+                        Encoding.UTF8,
+                        contentType);
                     result = new HttpRequestMessage(HttpMethod.Put, resourceIdentifier);
                     result.Content = requestContent;
                     requestContent = null;
@@ -611,12 +604,10 @@ namespace Microsoft.SCIM
                 HttpContent requestContent = null;
                 try
                 {
-                    MediaTypeFormatter contentFormatter = new JsonMediaTypeFormatter();
-                    requestContent =
-                        new ObjectContent<Dictionary<string, object>>(
-                            json,
-                            contentFormatter,
-                            contentType);
+                    requestContent = new StringContent(
+                        JsonConvert.SerializeObject(json),
+                        Encoding.UTF8,
+                        contentType);
                     result = new HttpRequestMessage(HttpMethod.Post, typeResourceIdentifier);
                     result.Content = requestContent;
                     requestContent = null;

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Service/Controllers/BulkRequestController.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Service/Controllers/BulkRequestController.cs
@@ -11,7 +11,6 @@ namespace Microsoft.SCIM
     using System.Net;
     using System.Net.Http;
     using System.Threading.Tasks;
-    using System.Web.Http;
 
     [Route(ServiceConstants.RouteBulk)]
     [Authorize]

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Service/Controllers/ControllerTemplate.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Service/Controllers/ControllerTemplate.cs
@@ -8,9 +8,7 @@ namespace Microsoft.SCIM
     using System.Net;
     using System.Net.Http;
     using System.Threading.Tasks;
-    using System.Web.Http;
     using Microsoft.AspNetCore.Mvc;
-    using Microsoft.AspNetCore.Mvc.WebApiCompatShim;
 
     public abstract class ControllerTemplate : ControllerBase
     {
@@ -39,7 +37,7 @@ namespace Microsoft.SCIM
 
             if (!this.Response.Headers.ContainsKey(ControllerTemplate.HeaderKeyContentType))
             {
-                this.Response.Headers.Add(ControllerTemplate.HeaderKeyContentType, ProtocolConstants.ContentType);
+                this.Response.Headers[ControllerTemplate.HeaderKeyContentType] = ProtocolConstants.ContentType;
             }
 
             Uri baseResourceIdentifier = this.ConvertRequest().GetBaseResourceIdentifier();
@@ -47,14 +45,19 @@ namespace Microsoft.SCIM
             string resourceLocation = resourceIdentifier.AbsoluteUri;
             if (!this.Response.Headers.ContainsKey(ControllerTemplate.HeaderKeyLocation))
             {
-                this.Response.Headers.Add(ControllerTemplate.HeaderKeyLocation, resourceLocation);
+                this.Response.Headers[ControllerTemplate.HeaderKeyLocation] = resourceLocation;
             }
         }
 
         protected HttpRequestMessage ConvertRequest()
         {
-            HttpRequestMessageFeature hreqmf = new HttpRequestMessageFeature(this.HttpContext);
-            HttpRequestMessage result = hreqmf.HttpRequestMessage;
+            var req = this.HttpContext.Request;
+            var uri = new Uri($"{req.Scheme}://{req.Host}{req.Path}{req.QueryString}");
+            var result = new HttpRequestMessage(new HttpMethod(req.Method), uri);
+            foreach (var header in req.Headers)
+            {
+                result.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray());
+            }
             return result;
         }
 
@@ -284,7 +287,7 @@ namespace Microsoft.SCIM
 
         [HttpGet(ControllerTemplate.AttributeValueIdentifier)]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get", Justification = "The names of the methods of a controller must correspond to the names of hypertext markup verbs")]
-        public virtual async Task<IActionResult> Get([FromUri]string identifier)
+        public virtual async Task<IActionResult> Get([FromQuery]string identifier)
         {
             string correlationIdentifier = null;
             try

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Service/Controllers/ControllerTemplate.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Service/Controllers/ControllerTemplate.cs
@@ -287,7 +287,7 @@ namespace Microsoft.SCIM
 
         [HttpGet(ControllerTemplate.AttributeValueIdentifier)]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get", Justification = "The names of the methods of a controller must correspond to the names of hypertext markup verbs")]
-        public virtual async Task<IActionResult> Get([FromQuery]string identifier)
+        public virtual async Task<IActionResult> Get([FromRoute]string identifier)
         {
             string correlationIdentifier = null;
             try

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Service/Controllers/ResourceTypesController.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Service/Controllers/ResourceTypesController.cs
@@ -6,7 +6,6 @@ namespace Microsoft.SCIM
     using System.Collections.Generic;
     using System.Net;
     using System.Net.Http;
-    using System.Web.Http;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
 

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Service/Controllers/SchemasController.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Service/Controllers/SchemasController.cs
@@ -6,7 +6,6 @@ namespace Microsoft.SCIM
     using System.Collections.Generic;
     using System.Net;
     using System.Net.Http;
-    using System.Web.Http;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
 

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Service/Controllers/ServiceProviderConfigurationController.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Service/Controllers/ServiceProviderConfigurationController.cs
@@ -5,7 +5,6 @@ namespace Microsoft.SCIM
     using System;
     using System.Net;
     using System.Net.Http;
-    using System.Web.Http;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
 

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Service/HttpResponseException.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Service/HttpResponseException.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.// Licensed under the MIT license.
+
+namespace Microsoft.SCIM
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+
+    public class HttpResponseException : Exception
+    {
+        public HttpResponseException(HttpStatusCode statusCode)
+            : base(statusCode.ToString())
+        {
+            Response = new HttpResponseMessage(statusCode);
+        }
+
+        public HttpResponseException(HttpResponseMessage response)
+            : base(response?.StatusCode.ToString())
+        {
+            Response = response;
+        }
+
+        public HttpResponseMessage Response { get; }
+    }
+}

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Service/HttpResponseExceptionFactory.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Service/HttpResponseExceptionFactory.cs
@@ -4,7 +4,6 @@ namespace Microsoft.SCIM
 {
     using System.Net;
     using System.Net.Http;
-    using System.Web.Http;
 
     internal abstract class HttpResponseExceptionFactory<T>
     {

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Service/IProvider.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Service/IProvider.cs
@@ -5,7 +5,6 @@ namespace Microsoft.SCIM
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using System.Web.Http;
     using Microsoft.AspNetCore.Builder;
 
     public interface IProvider

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Service/RequestExtensions.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Service/RequestExtensions.cs
@@ -6,7 +6,6 @@ namespace Microsoft.SCIM
     using System.Linq;
     using System.Net;
     using System.Net.Http;
-    using System.Web.Http;
     using System.Collections.Generic;
     using Newtonsoft.Json;
 

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Service/ResourceQuery.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Service/ResourceQuery.cs
@@ -9,7 +9,6 @@ namespace Microsoft.SCIM
     using System.Linq;
     using System.Net;
     using System.Web;
-    using System.Web.Http;
 
     public sealed class ResourceQuery : IResourceQuery
     {

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Service/RootProviderAdapter .cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Service/RootProviderAdapter .cs
@@ -6,7 +6,6 @@ namespace Microsoft.SCIM
     using System.Net;
     using System.Net.Http;
     using System.Threading.Tasks;
-    using System.Web.Http;
 
     internal class RootProviderAdapter : ProviderAdapterTemplate<Resource>
     {

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Service/SampleProvider.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Service/SampleProvider.cs
@@ -8,7 +8,6 @@ namespace Microsoft.SCIM
     using System.Linq;
     using System.Net;
     using System.Threading.Tasks;
-    using System.Web.Http;
     using Newtonsoft.Json;
 
     public sealed class SampleProvider : ProviderBase, ISampleProvider

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Service/SchematizedMediaTypeFormatter.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Service/SchematizedMediaTypeFormatter.cs
@@ -7,14 +7,12 @@ namespace Microsoft.SCIM
     using System.IO;
     using System.Net;
     using System.Net.Http;
-    using System.Net.Http.Formatting;
     using System.Net.Http.Headers;
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
-    using System.Web.Http;
 
-    public sealed class SchematizedMediaTypeFormatter : MediaTypeFormatter
+    public sealed class SchematizedMediaTypeFormatter
     {
         private static readonly Encoding Encoding = Encoding.UTF8;
 
@@ -52,6 +50,8 @@ namespace Microsoft.SCIM
             this.DeserializingFactory = deserializingFactory ?? throw new ArgumentNullException(nameof(deserializingFactory));
         }
 
+        public IList<MediaTypeHeaderValue> SupportedMediaTypes { get; } = new List<MediaTypeHeaderValue>();
+
         private JsonDeserializingFactory<Schematized> DeserializingFactory
         {
             get;
@@ -71,7 +71,7 @@ namespace Microsoft.SCIM
             return result;
         }
 
-        public override bool CanReadType(Type type)
+        public bool CanReadType(Type type)
         {
             if (null == type)
             {
@@ -82,7 +82,7 @@ namespace Microsoft.SCIM
             return result;
         }
 
-        public override bool CanWriteType(Type type)
+        public bool CanWriteType(Type type)
         {
             if (null == type)
             {
@@ -175,25 +175,24 @@ namespace Microsoft.SCIM
             }
             catch (ArgumentException)
             {
-                return new HttpResponseException(HttpStatusCode.BadRequest);
+                throw new HttpResponseException(HttpStatusCode.BadRequest);
             }
             catch (NotSupportedException)
             {
-                return new HttpResponseException(HttpStatusCode.BadRequest);
+                throw new HttpResponseException(HttpStatusCode.BadRequest);
             }
 #pragma warning disable CA1031 // Do not catch general exception types
             catch
             {
-                return new HttpResponseException(HttpStatusCode.BadRequest);
+                throw new HttpResponseException(HttpStatusCode.BadRequest);
             }
 #pragma warning restore CA1031 // Do not catch general exception types
         }
 
-        public override Task<object> ReadFromStreamAsync(
+        public Task<object> ReadFromStreamAsync(
             Type type,
             Stream readStream,
-            HttpContent content,
-            IFormatterLogger formatterLogger)
+            HttpContent content)
         {
             if (null == type)
             {
@@ -209,16 +208,15 @@ namespace Microsoft.SCIM
             return result;
         }
 
-        public override Task<object> ReadFromStreamAsync(
+        public Task<object> ReadFromStreamAsync(
             Type type,
             Stream readStream,
             HttpContent content,
-            IFormatterLogger formatterLogger,
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            return this.ReadFromStreamAsync(type, readStream, content, formatterLogger);
+            return this.ReadFromStreamAsync(type, readStream, content);
         }
 
         private async Task WriteToStream(
@@ -281,7 +279,7 @@ namespace Microsoft.SCIM
             writeStream.Flush();
         }
 
-        public override Task WriteToStreamAsync(
+        public Task WriteToStreamAsync(
             Type type,
             object value,
             Stream writeStream,
@@ -306,7 +304,7 @@ namespace Microsoft.SCIM
             return result;
         }
 
-        public override Task WriteToStreamAsync(
+        public Task WriteToStreamAsync(
             Type type,
             object value,
             Stream writeStream,


### PR DESCRIPTION
## Summary
- Upgrade all projects to `net10.0` target framework
- Remove abandoned `Microsoft.AspNetCore.Mvc.WebApiCompatShim` (last released 2018, no .NET 5+ support) and other packages superseded by `<FrameworkReference Include="Microsoft.AspNetCore.App" />`
- Add drop-in `HttpResponseException` class to replace the Web API 2 type previously provided by the compat shim
- Rewrite `ConvertRequest()` to build `HttpRequestMessage` directly from `HttpContext.Request` (replacing `HttpRequestMessageFeature` from compat shim)
- Remove `MediaTypeFormatter` inheritance from `SchematizedMediaTypeFormatter` (base type was from compat shim)
- Replace `ObjectContent<T>`/`JsonMediaTypeFormatter` usages in `ProtocolExtensions` with `StringContent` + `JsonConvert.SerializeObject`
- Migrate `[FromUri]` → `[FromQuery]` attribute
- Bump `System.IdentityModel.Tokens.Jwt` 6.25.1 → 8.18.0 to resolve moderate vulnerability GHSA-59j7-ghrg-fj52
- Add explicit `Microsoft.AspNetCore.Authentication.JwtBearer` 10.0.8 reference to WebHostSample
- Version bump to 1.0.6
- Jira: [CA-11833](https://criticalarc.atlassian.net/browse/CA-11833)

## Test plan
- [x] `dotnet build` succeeds with 0 errors
- [x] No NuGet vulnerability warnings in build output
- [x] `dotnet test` passes (1 test)
- [x] WebHostSample starts and responds to SCIM requests