### PR TITLE
CA-11833: Fix ConvertRequest() to preserve PathBase and HttpContext options

### DIFF
--- a/Microsoft.SystemForCrossDomainIdentityManagement/Microsoft.SCIM.csproj
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Microsoft.SCIM.csproj
@@ -5,10 +5,10 @@
     <TargetFramework>net10.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Title>Microsoft SCIM</Title>
-    <AssemblyVersion>1.0.6</AssemblyVersion>
-    <Version>1.0.6</Version>
-    <FileVersion>1.0.6</FileVersion>
-    <PackageVersion>1.0.6</PackageVersion>
+    <AssemblyVersion>1.0.7</AssemblyVersion>
+    <Version>1.0.7</Version>
+    <FileVersion>1.0.7</FileVersion>
+    <PackageVersion>1.0.7</PackageVersion>
     <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>
 

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Service/Controllers/ControllerTemplate.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Service/Controllers/ControllerTemplate.cs
@@ -8,6 +8,7 @@ namespace Microsoft.SCIM
     using System.Net;
     using System.Net.Http;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
 
     public abstract class ControllerTemplate : ControllerBase
@@ -52,12 +53,14 @@ namespace Microsoft.SCIM
         protected HttpRequestMessage ConvertRequest()
         {
             var req = this.HttpContext.Request;
-            var uri = new Uri($"{req.Scheme}://{req.Host}{req.Path}{req.QueryString}");
+            var fullPath = req.PathBase + req.Path;
+            var uri = new Uri($"{req.Scheme}://{req.Host}{fullPath}{req.QueryString}");
             var result = new HttpRequestMessage(new HttpMethod(req.Method), uri);
             foreach (var header in req.Headers)
             {
                 result.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray());
             }
+            result.Options.Set(new HttpRequestOptionsKey<HttpContext>(nameof(HttpContext)), this.HttpContext);
             return result;
         }
 


### PR DESCRIPTION
## Summary

- **Bug 1 – missing PathBase**: URI was built as `{scheme}://{host}{req.Path}`, dropping `req.PathBase`. `GetBaseResourceIdentifier()` calls `.Last()` on path segments and threw `InvalidOperationException: Sequence contains no elements` when the host setup places the full path in `PathBase` (e.g. unit tests and some proxy configurations).
- **Bug 2 – HttpContext dropped from options**: The old `HttpRequestMessageFeature`-based implementation automatically stored `HttpContext` in the message properties dictionary. The rewrite omitted the equivalent `result.Options.Set(new HttpRequestOptionsKey<HttpContext>(nameof(HttpContext)), this.HttpContext)`, causing custom `GetTenantId()` overrides (e.g. `SafeZoneScimProviderAdapterTemplateBase`) to throw `UnauthorizedAccessException` on every request.

## Test plan

- [x] All `SafeZoneScimGroupControllerTests` pass (were 5 failing before this fix)
- [x] All `SafeZoneScimUserControllerTests` pass
- [x] All SCIM adapter tests pass (147 total)
- [x] NuGet package rebuilt as 1.0.7 and pushed to criticalarc feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)